### PR TITLE
zig_translate_c: handle cc_toolchain configuration

### DIFF
--- a/zig/private/common/zig_translate_c.bzl
+++ b/zig/private/common/zig_translate_c.bzl
@@ -119,9 +119,11 @@ def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
             libc_txt = ctx.actions.declare_file("libc.txt")
             ctx.actions.write(
                 libc_txt,
+                # translate-c doesn't need crt_dir
+                # which is a blessing because we have no way to get it from the cc_toolchain
                 """include_dir={include_dir}
 sys_include_dir={sys_include_dir}
-crt_dir=
+crt_dir=/dev/null
 msvc_lib_dir=
 kernel32_lib_dir=
 gcc_dir=

--- a/zig/private/common/zig_translate_c.bzl
+++ b/zig/private/common/zig_translate_c.bzl
@@ -115,7 +115,7 @@ def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
         if cc_toolchain.sysroot:
             sysroot = cc_toolchain.sysroot
 
-        if sysroot:
+        if sysroot and sysroot != "/dev/null":
             libc_txt = ctx.actions.declare_file("libc.txt")
             ctx.actions.write(
                 libc_txt,

--- a/zig/private/common/zig_translate_c.bzl
+++ b/zig/private/common/zig_translate_c.bzl
@@ -2,6 +2,58 @@ load("//zig/private/providers:zig_module_info.bzl", "zig_module_info")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 
+# { option: takes_value }
+# translate-c only supports a limited set of clang options.
+_TRANSLATE_C_OPTIONS_ALLOW_LIST = {
+    "-isystem": True,
+    "-idirafter": True,
+    "-I": False,
+    "-D": False,
+}
+
+def _find_option_argument(command_line, option_name):
+    for i in range(len(command_line)):
+        arg = command_line[i]
+        if arg.startswith(option_name + "="):
+            # Case: --option=value or -isystem=/path
+            return arg.split("=", 1)[1]
+        elif arg == option_name:
+            # Case: --option value or -isystem /path
+            if i + 1 < len(command_line):
+                return command_line[i + 1]
+    return None  # Not found
+
+def _filter_options(command_line, allow_list):
+    filtered_command_line = []
+    skip_next = False
+    for i in range(len(command_line)):
+        if skip_next:
+            skip_next = False
+            continue
+
+        arg = command_line[i]
+        # Check for exact match, possibly with '='
+        option_name = arg.split("=", 1)[0]
+        if option_name in allow_list:
+            expects_value = allow_list[option_name]
+            if "=" in arg:
+                # Handle options like -isystem=/path (=value)
+                filtered_command_line.append(arg)
+            else:
+                # Handle the separate forms like -isystem /path
+                filtered_command_line.append(arg)
+                if expects_value and i + 1 < len(command_line):
+                    filtered_command_line.append(command_line[i + 1])
+                    skip_next = True
+        else:
+            # Handle options like -I/usr/include (prefix match)
+            for opt in allow_list:
+                if not allow_list[opt] and arg.startswith(opt):
+                    filtered_command_line.append(arg)
+                    break
+
+    return filtered_command_line
+
 def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
     cc_info = cc_common.merge_cc_infos(direct_cc_infos = cc_infos)
     compilation_context = cc_info.compilation_context
@@ -32,54 +84,59 @@ def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
     # If there is a CC toolchain, add its path there
     cc_toolchain = find_cc_toolchain(ctx)
 
-    feature_configuration = cc_common.configure_features(
-        ctx = ctx,
-        cc_toolchain = cc_toolchain,
-        requested_features = [],
-        unsupported_features = [],
-    )
-
-    c_compile_variables = cc_common.create_compile_variables(
-        feature_configuration = feature_configuration,
-        cc_toolchain = cc_toolchain,
-        user_compile_flags = ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts,
-    )
-
-    command_line = cc_common.get_memory_inefficient_command_line(
-        feature_configuration = feature_configuration,
-        action_name = C_COMPILE_ACTION_NAME,
-        variables = c_compile_variables,
-    )
-
-    new_command_line = []
-    for arg in command_line:
-        if arg.startswith("--sysroot="):
-            new_command_line.append("--sysroot")
-            new_command_line.append(arg[len("--sysroot="):])
-            new_command_line.append("-isystem")
-            new_command_line.append("{}/usr/include".format(arg[len("--sysroot="):]))
-        else:
-            new_command_line.append(arg)
-    command_line = new_command_line
-
-    new_command_line = []
-    for i in range(len(command_line)):
-        flag = command_line[i]
-        if flag in ["--sysroot", "-isystem", "-iquote"]:
-            if i + 1 < len(command_line):
-                new_command_line.append(flag)
-                new_command_line.append(command_line[i + 1])
-            else:
-                pass
-
-    command_line = new_command_line
-
-    args.add_all(command_line)
-
-    if (cc_toolchain):
+    additional_args = []
+    additional_inputs = []
+    if cc_toolchain:
         args.add_all(cc_toolchain.built_in_include_directories, before_each = "-isystem")
 
-    inputs = depset(direct = [hdr], transitive = [compilation_context.headers, cc_toolchain.all_files])
+        feature_configuration = cc_common.configure_features(
+            ctx = ctx,
+            cc_toolchain = cc_toolchain,
+            requested_features = [],
+            unsupported_features = [],
+        )
+        c_compile_variables = cc_common.create_compile_variables(
+            feature_configuration = feature_configuration,
+            cc_toolchain = cc_toolchain,
+            user_compile_flags = ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts,
+        )
+        command_line = cc_common.get_memory_inefficient_command_line(
+            feature_configuration = feature_configuration,
+            action_name = C_COMPILE_ACTION_NAME,
+            variables = c_compile_variables,
+        )
+
+        # extracting possible sysroot before filtering the command line
+        sysroot = _find_option_argument(command_line, "--sysroot")
+        command_line = _filter_options(command_line, _TRANSLATE_C_OPTIONS_ALLOW_LIST)
+
+        args.add_all(command_line)
+
+        if cc_toolchain.sysroot:
+            sysroot = cc_toolchain.sysroot
+
+        if sysroot:
+            libc_txt = ctx.actions.declare_file("libc.txt")
+            ctx.actions.write(
+                libc_txt,
+                """include_dir={include_dir}
+sys_include_dir={sys_include_dir}
+crt_dir=
+msvc_lib_dir=
+kernel32_lib_dir=
+gcc_dir=
+""".format(
+                include_dir = "{}/usr/include".format(sysroot),
+                sys_include_dir = "{}/usr/include".format(sysroot),
+                ),
+            )
+            additional_args.append("--libc")
+            additional_args.append(libc_txt.path)
+            additional_inputs.append(libc_txt)
+
+    args.add_all(additional_args)
+
+    inputs = depset(direct = [hdr] + additional_inputs, transitive = [compilation_context.headers, cc_toolchain.all_files])
     ctx.actions.run_shell(
         command = "${{@}} > {}".format(zig_out.path),
         inputs = inputs,

--- a/zig/private/common/zig_translate_c.bzl
+++ b/zig/private/common/zig_translate_c.bzl
@@ -1,5 +1,6 @@
 load("//zig/private/providers:zig_module_info.bzl", "zig_module_info")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 
 def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
     cc_info = cc_common.merge_cc_infos(direct_cc_infos = cc_infos)
@@ -30,10 +31,55 @@ def zig_translate_c(*, ctx, zigtoolchaininfo, zig_config_args, cc_infos):
 
     # If there is a CC toolchain, add its path there
     cc_toolchain = find_cc_toolchain(ctx)
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = [],
+        unsupported_features = [],
+    )
+
+    c_compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        user_compile_flags = ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts,
+    )
+
+    command_line = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = C_COMPILE_ACTION_NAME,
+        variables = c_compile_variables,
+    )
+
+    new_command_line = []
+    for arg in command_line:
+        if arg.startswith("--sysroot="):
+            new_command_line.append("--sysroot")
+            new_command_line.append(arg[len("--sysroot="):])
+            new_command_line.append("-isystem")
+            new_command_line.append("{}/usr/include".format(arg[len("--sysroot="):]))
+        else:
+            new_command_line.append(arg)
+    command_line = new_command_line
+
+    new_command_line = []
+    for i in range(len(command_line)):
+        flag = command_line[i]
+        if flag in ["--sysroot", "-isystem", "-iquote"]:
+            if i + 1 < len(command_line):
+                new_command_line.append(flag)
+                new_command_line.append(command_line[i + 1])
+            else:
+                pass
+
+    command_line = new_command_line
+
+    args.add_all(command_line)
+
     if (cc_toolchain):
         args.add_all(cc_toolchain.built_in_include_directories, before_each = "-isystem")
 
-    inputs = depset(direct = [hdr], transitive = [compilation_context.headers])
+    inputs = depset(direct = [hdr], transitive = [compilation_context.headers, cc_toolchain.all_files])
     ctx.actions.run_shell(
         command = "${{@}} > {}".format(zig_out.path),
         inputs = inputs,

--- a/zig/private/zig_binary.bzl
+++ b/zig/private/zig_binary.bzl
@@ -52,4 +52,5 @@ zig_binary = rule(
     doc = DOC,
     executable = True,
     toolchains = TOOLCHAINS,
+    fragments = ["cpp"],
 )


### PR DESCRIPTION
This PR configures translate-c to use a custom libc installation if we detect sysroot configuration from the cc toolchain.
Additionally, it passes compatible options from the cc_toolchain configuration if there are any.
