### PR TITLE
Fix zls_completion requirements on CppConfiguration

### DIFF
--- a/zig/private/zls_completion.bzl
+++ b/zig/private/zls_completion.bzl
@@ -83,5 +83,6 @@ zls_completion = rule(
         ),
     },
     toolchains = TOOLCHAINS,
+    fragments = ["cpp"],
     executable =  True,
 )


### PR DESCRIPTION
Any rule using zig_tranlate_c now requires fragments=cpp