### PR TITLE
Removes `-fcompiler-rt` flag for test_lib

### DIFF
--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -380,7 +380,6 @@ def zig_build_impl(ctx, *, kind):
     elif kind == BINARY_KIND.test_lib:
         outputs.append(output)
         args.add(output, format = "-femit-llvm-bc=%s")
-        args.add("-fcompiler-rt")
         if ctx.attr.test_runner:
             args.add("--test-runner", ctx.file.test_runner)
         arguments = ["test", "-fno-emit-bin", zig_config_args, args]
@@ -420,7 +419,6 @@ def zig_build_impl(ctx, *, kind):
         libargs = ctx.actions.args()
 
         libargs.add(output, format = "-femit-bin=%s")
-        libargs.add("-fcompiler-rt")
         libargs.add(bcinput)
 
         ctx.actions.run(


### PR DESCRIPTION
There is no reason compiler-rt builtins are not provided downstream. And if they weren't it would be a problem for downstream.