### PR TITLE
Adds dummy executable for non-`exe` binary kinds

### DIFF
--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -448,8 +448,18 @@ def zig_build_impl(ctx, *, kind):
         providers.append(cc_info)
 
     files = depset([output])
+
+    dummy = None
+    if kind != BINARY_KIND.exe:
+        dummy = ctx.actions.declare_file(ctx.label.name + ".exe.dummy")
+        ctx.actions.write(
+            output = dummy,
+            content = "",
+            is_executable = True,
+        )
+
     default = DefaultInfo(
-        executable = output,
+        executable = output if kind == BINARY_KIND.exe else dummy,
         files = files,
         runfiles = zig_create_runfiles(
             ctx_runfiles = ctx.runfiles,


### PR DESCRIPTION
This is because we use an executable rule (zig_binary) for all kind of output, even non executables (kind = static-lib for instance).

The real solution is to split between zig_binaries and zig_non_executable_binaries in a macro a la rules_go.