### PR TITLE
fix: deduplicate -I and -isystem include paths

### DIFF
--- a/zig/private/common/cdeps.bzl
+++ b/zig/private/common/cdeps.bzl
@@ -11,15 +11,35 @@ def zig_cdeps_copts(*, compilation_context, args, transitive_inputs):
         transitive_inputs: List; mutable, Append inputs to this collection.
     """
     args.add_all(compilation_context.defines, format_each = "-D%s")
-    args.add_all(compilation_context.includes, format_each = "-I%s")
+
+    # Collect all paths that will be emitted as -isystem so we can prevent
+    # the same path from also being emitted as -I (which would cause
+    # duplicate include warnings).
+    system_set = {p: True for p in compilation_context.system_includes.to_list()}
+    # Added in Bazel 7, see https://github.com/bazelbuild/bazel/commit/a6ef0b341a8ffe8ab27e5ace79d8eaae158c422b
+    external_includes = getattr(compilation_context, "external_includes", None)
+    if external_includes:
+        system_set.update({p: True for p in external_includes.to_list()})
+
+    if system_set:
+        args.add_all(
+            [p for p in compilation_context.includes.to_list() if p not in system_set],
+            format_each = "-I%s",
+        )
+    else:
+        args.add_all(compilation_context.includes, format_each = "-I%s")
 
     # Note, Zig does not support `-iquote` as of Zig 0.12.0
     # args.add_all(compilation_context.quote_includes, format_each = "-iquote%s")
-    args.add_all(compilation_context.quote_includes, format_each = "-I%s")
-    args.add_all(compilation_context.system_includes, before_each = "-isystem")
-    if hasattr(compilation_context, "external_includes"):
-        # Added in Bazel 7, see https://github.com/bazelbuild/bazel/commit/a6ef0b341a8ffe8ab27e5ace79d8eaae158c422b
-        args.add_all(compilation_context.external_includes, before_each = "-isystem")
+    if system_set:
+        args.add_all(
+            [p for p in compilation_context.quote_includes.to_list() if p not in system_set],
+            format_each = "-I%s",
+        )
+    else:
+        args.add_all(compilation_context.quote_includes, format_each = "-I%s")
+
+    args.add_all(system_set.keys(), before_each = "-isystem")
     args.add_all(compilation_context.framework_includes, format_each = "-F%s")
 
     transitive_inputs.append(compilation_context.headers)

--- a/zig/private/common/cdeps.bzl
+++ b/zig/private/common/cdeps.bzl
@@ -23,8 +23,10 @@ def zig_cdeps_copts(*, compilation_context, args, transitive_inputs):
 
     if system_set:
         args.add_all(
-            [p for p in compilation_context.includes.to_list() if p not in system_set],
+            compilation_context.includes,
+            map_each = _make_system_filter(system_set),
             format_each = "-I%s",
+            allow_closure = True,
         )
     else:
         args.add_all(compilation_context.includes, format_each = "-I%s")
@@ -33,13 +35,17 @@ def zig_cdeps_copts(*, compilation_context, args, transitive_inputs):
     # args.add_all(compilation_context.quote_includes, format_each = "-iquote%s")
     if system_set:
         args.add_all(
-            [p for p in compilation_context.quote_includes.to_list() if p not in system_set],
+            compilation_context.quote_includes,
+            map_each = _make_system_filter(system_set),
             format_each = "-I%s",
+            allow_closure = True,
         )
     else:
         args.add_all(compilation_context.quote_includes, format_each = "-I%s")
 
-    args.add_all(system_set.keys(), before_each = "-isystem")
+    args.add_all(compilation_context.system_includes, before_each = "-isystem")
+    if external_includes:
+        args.add_all(external_includes, before_each = "-isystem")
     args.add_all(compilation_context.framework_includes, format_each = "-F%s")
 
     transitive_inputs.append(compilation_context.headers)
@@ -104,6 +110,16 @@ def zig_cdeps_linker_inputs(*, linking_context, solib_parents, os, inputs, args,
         before_each = "-rpath",
         uniquify = True,
     )
+
+def _make_system_filter(system_set):
+    """Returns a map_each callback that filters out paths present in system_set."""
+
+    def _filter(path):
+        if path in system_set:
+            return None
+        return path
+
+    return _filter
 
 def _lib_flags(arg):
     (file, dynamic) = arg

--- a/zig/private/common/translate_c.bzl
+++ b/zig/private/common/translate_c.bzl
@@ -203,15 +203,35 @@ def zig_translate_c(*, ctx, name, canonical_name, zigtoolchaininfo, global_args,
 
         args.add_all(compilation_context.defines, format_each = "-D%s")
         args.add("-I.")
-        args.add_all(compilation_context.includes, format_each = "-I%s")
+
+        # Collect all paths that will be emitted as -isystem so we can prevent
+        # the same path from also being emitted as -I (which would cause
+        # duplicate include warnings).
+        system_set = {p: True for p in compilation_context.system_includes.to_list()}
+        # Added in Bazel 7, see https://github.com/bazelbuild/bazel/commit/a6ef0b341a8ffe8ab27e5ace79d8eaae158c422b
+        external_includes = getattr(compilation_context, "external_includes", None)
+        if external_includes:
+            system_set.update({p: True for p in external_includes.to_list()})
+
+        if system_set:
+            args.add_all(
+                [p for p in compilation_context.includes.to_list() if p not in system_set],
+                format_each = "-I%s",
+            )
+        else:
+            args.add_all(compilation_context.includes, format_each = "-I%s")
 
         # Note, Zig does not support `-iquote` as of Zig 0.12.0
         # args.add_all(compilation_context.quote_includes, format_each = "-iquote%s")
-        args.add_all(compilation_context.quote_includes, format_each = "-I%s")
-        args.add_all(compilation_context.system_includes, before_each = "-isystem")
+        if system_set:
+            args.add_all(
+                [p for p in compilation_context.quote_includes.to_list() if p not in system_set],
+                format_each = "-I%s",
+            )
+        else:
+            args.add_all(compilation_context.quote_includes, format_each = "-I%s")
 
-        # Added in Bazel 7, see https://github.com/bazelbuild/bazel/commit/a6ef0b341a8ffe8ab27e5ace79d8eaae158c422b
-        args.add_all(getattr(compilation_context, "external_includes", []), before_each = "-isystem")
+        args.add_all(system_set.keys(), before_each = "-isystem")
         args.add_all(compilation_context.framework_includes, format_each = "-F%s")
 
         zig_out = ctx.actions.declare_file("{}{}_c.zig".format(output_prefix, ctx.label.name))

--- a/zig/private/common/translate_c.bzl
+++ b/zig/private/common/translate_c.bzl
@@ -25,6 +25,16 @@ _FILTERED_ARGS = [
     "-Xclang",
 ]
 
+def _make_system_filter(system_set):
+    """Returns a map_each callback that filters out paths present in system_set."""
+
+    def _filter(path):
+        if path in system_set:
+            return None
+        return path
+
+    return _filter
+
 def _sanitize_commandline(args):
     ret = []
     skip_next = False
@@ -215,8 +225,10 @@ def zig_translate_c(*, ctx, name, canonical_name, zigtoolchaininfo, global_args,
 
         if system_set:
             args.add_all(
-                [p for p in compilation_context.includes.to_list() if p not in system_set],
+                compilation_context.includes,
+                map_each = _make_system_filter(system_set),
                 format_each = "-I%s",
+                allow_closure = True,
             )
         else:
             args.add_all(compilation_context.includes, format_each = "-I%s")
@@ -225,13 +237,17 @@ def zig_translate_c(*, ctx, name, canonical_name, zigtoolchaininfo, global_args,
         # args.add_all(compilation_context.quote_includes, format_each = "-iquote%s")
         if system_set:
             args.add_all(
-                [p for p in compilation_context.quote_includes.to_list() if p not in system_set],
+                compilation_context.quote_includes,
+                map_each = _make_system_filter(system_set),
                 format_each = "-I%s",
+                allow_closure = True,
             )
         else:
             args.add_all(compilation_context.quote_includes, format_each = "-I%s")
 
-        args.add_all(system_set.keys(), before_each = "-isystem")
+        args.add_all(compilation_context.system_includes, before_each = "-isystem")
+        if external_includes:
+            args.add_all(external_includes, before_each = "-isystem")
         args.add_all(compilation_context.framework_includes, format_each = "-F%s")
 
         zig_out = ctx.actions.declare_file("{}{}_c.zig".format(output_prefix, ctx.label.name))


### PR DESCRIPTION
# Problem

When Bazel's `cc_common.merge_cc_infos` merges C dependency info, `compilation_context.includes` and `compilation_context.quote_includes` can contain paths that also appear in `compilation_context.system_includes`. 
Since Zig does not support `-iquote`, both are forwarded as `-I`, while `system_includes` is forwarded as `-isystem`. 
In reality, we only witnessed duplicates in `quote_includes ∩ system_includes`. But the fix is defensive: it handles both fields.

For example, in `zml`'s `//examples/llm:llm`, paths like `com_google_sentencepiece` and `eigen_archive` appeared as both `-I` and `-isystem` in the ZigBuildLib action. See for instance : 
```
$ pwd
/home/ubuntu/repos/zml
$ bazel build //examples/llm
[...]
INFO: From zig build-lib //examples/llm:llm:
warning: add 'external/+xla+eigen_archive' to header searchlist '-isystem' conflicts with '-I'
warning: add 'bazel-out/host_glibc-dbg/bin/external/+xla+eigen_archive' to header searchlist '-isystem' conflicts with '-I'
warning: add 'external/libbacktrace+' to header searchlist '-isystem' conflicts with '-I'
warning: add 'bazel-out/host_glibc-dbg/bin/external/libbacktrace+' to header searchlist '-isystem' conflicts with '-I'
warning: add 'external/+non_module_deps+com_google_sentencepiece' to header searchlist '-isystem' conflicts with '-I'
warning: add 'bazel-out/host_glibc-dbg/bin/external/+non_module_deps+com_google_sentencepiece' to header searchlist '-isystem' conflicts with '-I'
INFO: Found 1 target...
Target //examples/llm:llm up-to-date:
  bazel-bin/examples/llm/llm
INFO: Elapsed time: 435.556s, Critical Path: 137.57s
INFO: 4822 processes: 1712 internal, 3110 processwrapper-sandbox.
INFO: Build completed successfully, 4822 total actions
```

# Root cause

Both `cdeps.bzl` and `translate_c.bzl` emitted `includes`, `quote_includes`, `system_includes`, and `external_includes` independently, without deduplicating paths that appear in multiple fields.

# Fix

In both `cdeps.bzl` and `translate_c.bzl`:
* Collect all system-style paths into a single `system_set` (`system_includes` ∪ `external_includes`).
* Subtract `system_set` from `includes` and `quote_includes` before emitting `-I` flags.
* Emit `-isystem` once from `system_set.keys()`.

# Validation

* rules_zig tests: 132/132 pass
* Consumer (`zml //examples/llm:llm`) ZigBuildLib action

In `../zml/MODULE.bazel`, instead of fetching the module remotely :
```diff
+ local_path_override(
+    module_name = "rules_zig",
+    path = "../rules_zig",
+)
- git_override(
-    module_name = "rules_zig",
-    commit = "b65a2bb460b9dbcbcc3231ba648c3c1a266c4eb5",
-    remote = "https://github.com/zml/rules_zig.git",
- )
```

Then, `bazel aquery '//examples/llm:llm' --output=jsonproto`  and check for `ZigBuildLib` actions:

  |  `-I` count | `-isystem` count | Duplicates
-- | -- | -- | --
Before | 156 | 22 | 4
After | 152 | 22 | 0



